### PR TITLE
Made TwiMLResult functions protected

### DIFF
--- a/src/Twilio.AspNet.Core/TwilioController.cs
+++ b/src/Twilio.AspNet.Core/TwilioController.cs
@@ -14,7 +14,7 @@ namespace Twilio.AspNet.Core
         /// <param name="response"></param>
         /// <returns></returns>
         // ReSharper disable once InconsistentNaming
-        public TwiMLResult TwiML(MessagingResponse response)
+        protected TwiMLResult TwiML(MessagingResponse response)
         {
             return new TwiMLResult(response);
         }
@@ -25,7 +25,7 @@ namespace Twilio.AspNet.Core
         /// <param name="response"></param>
         /// <returns></returns>
         // ReSharper disable once InconsistentNaming
-        public TwiMLResult TwiML(VoiceResponse response)
+        protected TwiMLResult TwiML(VoiceResponse response)
         {
             return new TwiMLResult(response);
         }


### PR DESCRIPTION
This address Swashbuckle's complaint thinking they are API endpoints. While they are public, swashbuckle complains and fails to render UI.